### PR TITLE
Fix: Prevent file from opening twice on selection

### DIFF
--- a/performance_spe_analyzer/performance_spe_anlyzer.html
+++ b/performance_spe_analyzer/performance_spe_anlyzer.html
@@ -245,12 +245,9 @@
                 }
             }
             
-            // 修复：添加点击事件监听器，触发文件选择对话框
-            fileLabel.addEventListener('click', function() {
-                fileInput.click();
-            });
-            
             // 处理文件选择
+            // Clicking the fileLabel will now rely on default browser behavior
+            // to trigger the change event on the nested fileInput.
             fileInput.addEventListener('change', function() {
                 if (this.files.length) {
                     handleFiles(this.files[0]);


### PR DESCRIPTION
Removed a redundant JavaScript click event listener on the file input label. The browser's default behavior for label elements containing an input is sufficient to trigger the file selection dialog. The explicit programmatic click was causing the file handling logic to execute twice.

This change ensures that selecting a file only triggers the file processing logic once.